### PR TITLE
Fix `HookChair`

### DIFF
--- a/lua/entities/duck_instrument_base/init.lua
+++ b/lua/entities/duck_instrument_base/init.lua
@@ -111,9 +111,6 @@ local function HookChair( ply, ent )
 		return false
 
 	end
-
-	return true
-
 end
 
 -- Quick fix for overriding the instrument chair seating


### PR DESCRIPTION
Currently `HookChair` always returns true, preventing other addons and hooks from blocking `PlayerUse` or `CanPlayerEnterVehicle` attempts